### PR TITLE
Add a degree of abstraction to the storage client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 yarn.lock
+package-lock.json
+*.tgz

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@
 
 var redis = require('redis');
 var bluebird = require('bluebird');
+const storageProviders = {}
 
 function makeRedisClient() {
   bluebird.promisifyAll(redis.RedisClient.prototype);
@@ -41,16 +42,9 @@ function makeRedisClient() {
   return client;
 }
 
-async function makeStorageClient(web = false) {
-  let StorageClass = undefined;
-  try {
-    const {Storage} = require('@google-cloud/storage');
-    StorageClass = Storage;
-  } catch (err) {
-    throw new Error(
-      'No object store client is available in this action runtime'
-    );
-  }
+// The current contract of makeStorageClientis to return StorageClient handle.
+// This works for all object store implementations.
+function makeStorageClient(web = false) {
   const creds = process.env['__NIM_STORAGE_KEY'];
   if (!creds || creds.length == 0) {
     throw new Error('Objectstore credentials are not available');
@@ -59,30 +53,35 @@ async function makeStorageClient(web = false) {
   const apiHost = process.env['__OW_API_HOST'];
   if (!namespace || !apiHost) {
     throw new Error(
-      'Not enough information in the environment to determine the object store bucket name'
+      'Not enough information in the environment to build an object store client'
     );
   }
-  const hostpart = apiHost.replace('https://', '').split('.').join('-');
-  const datapart = web ? '' : 'data-';
-  const bucket = `gs://${datapart}${namespace}-${hostpart}`;
   let parsedCreds = undefined;
   try {
     parsedCreds = JSON.parse(creds);
-  } catch {}
-  if (parsedCreds) {
-    const {client_email, project_id, private_key} = parsedCreds;
-    if (client_email && project_id && private_key) {
-      const storageOptions = {
-        project_id,
-        credentials: {client_email, private_key}
-      };
-      const storage = new StorageClass(storageOptions);
-      return storage.bucket(bucket); // a promise, since the function is async
-    }
+  } catch {
+    throw new Error(
+      'Objectstore credentials could not be parsed'
+    );
   }
-  throw new Error(
-    'Insufficient information in provided credentials or credentials were invalid'
-  );
+  const provider = parsedCreds.provider || '@nimbella/storage-gcs'
+  let providerImpl = storageProviders[provider]
+  if (!providerImpl) {
+    providerImpl = require(provider).default
+    storageProviders[provider] = providerImpl
+  }
+  const creds = providerImpl.prepareCredentials(parsedCreds)
+  return providerImpl.getClient(namespace, apiHost, web, creds)
+}
+
+// The legacy behavior of makeStorageClient is defined only for Google cloud storage
+async function legacyMakeStorageClient(web = false) {
+  const handle = makeStorageClient(web)
+  if ('@nimbella/storage-gcs' in storageProviders) {
+    // Not really a foolproof test but will usually screen errors
+    return handle
+  }
+  throw new Error('Cannot return a Bucket result because the implementation is not Google Storage')
 }
 
 async function makeSqlClient() {
@@ -106,6 +105,9 @@ async function makeSqlClient() {
 
 module.exports = {
   redis: makeRedisClient,
-  storage: makeStorageClient,
+  // Legacy function, returns Promise<Bucket>:
+  storage: legacyMakeStorageClient,
+  // New version of the function, returns the more abstract type StorageClient
+  storageClient: makeStorageClient,
   mysql: makeSqlClient
 };

--- a/index.js
+++ b/index.js
@@ -45,8 +45,8 @@ function makeRedisClient() {
 // The current contract of makeStorageClientis to return StorageClient handle.
 // This works for all object store implementations.
 function makeStorageClient(web = false) {
-  const creds = process.env['__NIM_STORAGE_KEY'];
-  if (!creds || creds.length == 0) {
+  const rawCreds = process.env['__NIM_STORAGE_KEY'];
+  if (!rawCreds || rawCreds.length == 0) {
     throw new Error('Objectstore credentials are not available');
   }
   const namespace = process.env['__OW_NAMESPACE'];
@@ -58,7 +58,7 @@ function makeStorageClient(web = false) {
   }
   let parsedCreds = undefined;
   try {
-    parsedCreds = JSON.parse(creds);
+    parsedCreds = JSON.parse(rawCreds);
   } catch {
     throw new Error(
       'Objectstore credentials could not be parsed'

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function makeStorageClient(web = false) {
     parsedCreds = JSON.parse(rawCreds);
   } catch {
     throw new Error(
-      'Objectstore credentials could not be parsed'
+      'Object store credentials could not be parsed'
     );
   }
   const provider = parsedCreds.provider || '@nimbella/storage-gcs'

--- a/index.js
+++ b/index.js
@@ -42,8 +42,8 @@ function makeRedisClient() {
   return client;
 }
 
-// The current contract of makeStorageClientis to return StorageClient handle.
-// This works for all object store implementations.
+// The current contract of makeStorageClientis to return a StorageClient handle.
+// This works for all object store implementations (currently GCS and S3)
 function makeStorageClient(web = false) {
   const rawCreds = process.env['__NIM_STORAGE_KEY'];
   if (!rawCreds || rawCreds.length == 0) {
@@ -79,7 +79,7 @@ async function legacyMakeStorageClient(web = false) {
   const handle = makeStorageClient(web)
   if ('@nimbella/storage-gcs' in storageProviders) {
     // Not really a foolproof test but will usually screen errors
-    return handle
+    return handle.getImplementation()
   }
   throw new Error('Cannot return a Bucket result because the implementation is not Google Storage')
 }
@@ -105,7 +105,7 @@ async function makeSqlClient() {
 
 module.exports = {
   redis: makeRedisClient,
-  // Legacy function, returns Promise<Bucket>:
+  // Legacy function, returns Promise<Bucket>
   storage: legacyMakeStorageClient,
   // New version of the function, returns the more abstract type StorageClient
   storageClient: makeStorageClient,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/nimbella/nimbella-sdk-nodejs",
   "dependencies": {
-    "@google-cloud/storage": "^5.3.0",
+    "@nimbella/storage-gcs": "0.0.4",
     "bluebird": "^3.7.2",
     "mysql2": "^2.1.0",
     "redis": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A Node.js library to interact with nimbella.com services.",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Node.js library to interact with nimbella.com services.",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/sdk",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A Node.js library to interact with nimbella.com services.",
   "main": "index.js",
   "license": "Apache-2.0",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/nimbella/nimbella-sdk-nodejs",
   "dependencies": {
-    "@nimbella/storage-gcs": "0.0.4",
+    "@nimbella/storage-gcs": "0.0.6",
     "bluebird": "^3.7.2",
     "mysql2": "^2.1.0",
     "redis": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/nimbella/nimbella-sdk-nodejs",
   "dependencies": {
     "@nimbella/storage-gcs": "0.0.6",
+    "@nimbella/storage-s3": "0.0.4",
     "bluebird": "^3.7.2",
     "mysql2": "^2.1.0",
     "redis": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/sdk",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A Node.js library to interact with nimbella.com services.",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/sdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A Node.js library to interact with nimbella.com services.",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
Currently, the function `storage()` returns a `Bucket` object (provided directly by Google Cloud Storage).   As we implement object storage for s3 a continuation of this approach would mean that there is little or no syntactic consistency when moving from platform to platform despite the high degree of resemblance between object store implementations at the semantic level.

This PR replaces the `Bucket` object with a `StorageClient` object which is a thin wrapper around a `Bucket` making the behavior more abstract and hiding google-specific features.   There is an alternate implementation in which the same `StorageClient` abstraction is wrapped around the `S3Client` handle used by the AWS SDK for S3 (version 3).

For backward compatibility, the behavior of `storage()` is unchanged.   However, it will throw an exception if the underlying implementation is s3 (in fact, anything other than Google Cloud Storage).   To get the new behavior, use `storageClient()`.   

Once you have a `StorageClient` you can reveal the underlying implementation (and break the abstraction) by calling its `getImplementation()` method.   That is, `storageClient().getImplementation()` is equivalent to `storage()`.   On S3, calling `getImplementation()` gets you an `S3Client`.   

It is TBD whether we will eventually deprecate and retire `storage()`.   If it happens, it will be a breaking change and hence the occasion of a major release.

Staying at the more abstract level you have all the capabilities defined in https://github.com/nimbella/nimbella-cli/blob/abstract-storage/storage/src/index.ts.   These are probably not all of the capabilities we will want to define abstractly in the long run for programmatic use.  They were chosen to cover everything that the nimbella CLI needs to have abstracted, which is probably more specialized.

The immediate consequence of merging this PR would be to make the change official for those building the SDK from this open source repo.   For most public uses of the SDK, however, the change will not become visible until the `latest` tag is updated for `@nimbella/sdk` which can be scheduled separately post-merge.   The code in this PR has been published, but with a `dev` tag.   As such it is incorporated in a related PR in the `nimbella/nimbella-cli` repo.